### PR TITLE
Allow passing redis connection settings via urlish

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -17,6 +17,12 @@ redisconfig =
 	port: parseInt(process.env.RS_REDISPORT or 6379, 10)
 	namespace: process.env.RS_NAMESPACE or "rs"
 loglevel = process.env.RS_LOGLEVEL or "dev"
+if process.env.RS_REDISURL
+  redisconfig =
+    namespace: process.env.RS_NAMESPACE or "rs"
+    options:
+      url: process.env.RS_REDISURL
+
 
 RedisSessions = require "redis-sessions"
 

--- a/app.js
+++ b/app.js
@@ -22,6 +22,15 @@ redisconfig = {
 
 loglevel = process.env.RS_LOGLEVEL || "dev";
 
+if (process.env.RS_REDISURL) {
+  redisconfig = {
+    namespace: process.env.RS_NAMESPACE || "rs",
+    options: {
+      url: process.env.RS_REDISURL
+    }
+  };
+}
+
 RedisSessions = require("redis-sessions");
 
 rs = new RedisSessions(redisconfig);


### PR DESCRIPTION
This facilitates passing redis authentication parameters such as username
and password from the runtime environment to redis.

redis-sessions looks for o.options.url, which is capable of passing most
parameters in one string.  If RS_REDISURL environment variable exists, it will
override the RS_REDISHOST and RS_REDISPORT variables.

Ability to pass these parameters is required to connect to any managed redis
providers.